### PR TITLE
Hotfix Remove index on organizer column in Meeting

### DIFF
--- a/db/migrate/20201202154555_add_author_to_meetings.decidim_meetings.rb
+++ b/db/migrate/20201202154555_add_author_to_meetings.decidim_meetings.rb
@@ -10,6 +10,7 @@ class AddAuthorToMeetings < ActiveRecord::Migration[5.2]
   def change
     add_column :decidim_meetings_meetings, :decidim_author_type, :string
     add_column :decidim_meetings_meetings, :decidim_user_group_id, :integer
+    remove_index :decidim_meetings_meetings, :organizer
 
     Meeting.reset_column_information
     Meeting.find_each do |meeting|


### PR DESCRIPTION
This PR changes the migration where organizer column is removed from Meeting. Since it has an index, some migrations might fall if they had data on it.